### PR TITLE
Angulartics-piwik plugin added

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,6 @@
     ],
     "dependencies": {
         "angulartics": "~1.0.3",
-        "angulartics-piwik": "~1.0.4",
         "showdown": "~1.3.0",
         "w20": "~2.3.0"
     },

--- a/bower.json
+++ b/bower.json
@@ -1,26 +1,27 @@
 {
-  "name": "w20-extras",
-  "version": "2.2.0",
-  "ignore": [
-    ".*",
-    "*.iml",
-    "specs",
-    "mocks",
-    "samples",
-    "bower_components",
-    "coverage",
-    "node_modules",
-    "gruntfile.js",
-    "karma.conf.js",
-    "package.json",
-    "test-main.js"
-  ],
-  "dependencies": {
-    "angulartics": "~1.0.3",
-    "showdown": "~1.3.0",
-    "w20": "~2.3.0"
-  },
-  "devDependencies": {
-    "angular-mocks": "~1.4.8"
-  }
+    "name": "w20-extras",
+    "version": "2.2.0",
+    "ignore": [
+        ".*",
+        "*.iml",
+        "specs",
+        "mocks",
+        "samples",
+        "bower_components",
+        "coverage",
+        "node_modules",
+        "gruntfile.js",
+        "karma.conf.js",
+        "package.json",
+        "test-main.js"
+    ],
+    "dependencies": {
+        "angulartics": "~1.0.3",
+        "angulartics-piwik": "~1.0.4",
+        "showdown": "~1.3.0",
+        "w20": "~2.3.0"
+    },
+    "devDependencies": {
+        "angular-mocks": "~1.4.8"
+    }
 }

--- a/modules/analytics.js
+++ b/modules/analytics.js
@@ -31,7 +31,7 @@ define([
         splunk: { suffix: 'splunk', plugin: false },
         woopra: { suffix: 'woopra', plugin: false },
         clicky: { suffix: 'clicky', plugin: true },
-        facebookPixel: { suffix: 'facebook-pixel', plugin: true },
+        'facebook-pixel': { suffix: 'facebook-pixel', plugin: true },
         hubspot: { suffix: 'hubspot', plugin: true },
         coremetrics: { suffix: 'coremetrics', plugin: true },
         localytics: { suffix: 'localytics', plugin: true },

--- a/modules/analytics.js
+++ b/modules/analytics.js
@@ -40,7 +40,7 @@ define([
             'and set it using the \'provider\' property in the analytic module configuration.');
     } else {
         if (configuredProvider.plugin) {
-            require(['{angulartics-' + configuredProvider.plugin + '}/src/angulartics-' + config.provider]);
+            require(['{angulartics-' + configuredProvider.suffix + '}/src/angulartics-' + config.provider]);
         } else {
             require(['{angulartics}/angulartics-' + config.provider]);
         }

--- a/modules/analytics.js
+++ b/modules/analytics.js
@@ -40,7 +40,7 @@ define([
             'and set it using the \'provider\' property in the analytic module configuration.');
     } else {
         if (configuredProvider.plugin) {
-            require(['{angulartics-' + configuredProvider.suffix + '}/src/angulartics-' + config.provider]);
+            require(['{angulartics-' + configuredProvider.suffix + '}/angulartics-' + config.provider]);
         } else {
             require(['{angulartics}/angulartics-' + config.provider]);
         }

--- a/modules/analytics.js
+++ b/modules/analytics.js
@@ -28,9 +28,15 @@ define([
         kissmetrics: { suffix: 'kissmetrics', plugin: true },
         mixpanel: { suffix: 'mixpanel', plugin: true },
         piwik: { suffix: 'piwik', settings: config.settings, plugin: true },
-        segmentio: { suffix: 'segment.io', plugin: true },
         splunk: { suffix: 'splunk', plugin: false },
-        woopra: { suffix: 'woopra', plugin: false }
+        woopra: { suffix: 'woopra', plugin: false },
+        clicky: { suffix: 'clicky', plugin: true },
+        facebookPixel: { suffix: 'facebook-pixel', plugin: true },
+        hubspot: { suffix: 'hubspot', plugin: true },
+        coremetrics: { suffix: 'coremetrics', plugin: true },
+        localytics: { suffix: 'localytics', plugin: true },
+        scout: { suffix: 'scout', plugin: true },
+        segment: { suffix: 'segment', plugin: true }
     };
 
     var configuredProvider = availableProviders[config.provider];

--- a/modules/analytics.js
+++ b/modules/analytics.js
@@ -13,33 +13,37 @@ define([
 
     '{angulartics}/angulartics'
 
-], function (module, require, angular) {
+], function(module, require, angular) {
     'use strict';
 
     var config = module && module.config() || {};
 
     var availableProviders = {
-        adobe:          { suffix: 'adobe.analytics' },
-        chartbeat:      { suffix: 'chartbeat' },
-        flurry:         { suffix: 'flurry' },
-        ga:             { suffix: 'google.analytics' },
-        'ga-cordova':   { suffix: 'google.analytics.cordova' },
-        gtm:            { suffix: 'google.tagmanager' },
-        kissmetrics:    { suffix: 'kissmetrics' },
-        mixpanel:       { suffix: 'mixpanel' },
-        piwik:          { suffix: 'piwik', settings: config.settings },
-        segmentio:      { suffix: 'segment.io' },
-        splunk:         { suffix: 'splunk' },
-        woopra:         { suffix: 'woopra' }
+        adobe: { suffix: 'adobe.analytics', plugin: true },
+        chartbeat: { suffix: 'chartbeat', plugin: true },
+        flurry: { suffix: 'flurry', plugin: true },
+        ga: { suffix: 'google.analytics', plugin: true },
+        'ga-cordova': { suffix: 'google.analytics.cordova', plugin: false },
+        gtm: { suffix: 'google.tagmanager', plugin: false },
+        kissmetrics: { suffix: 'kissmetrics', plugin: true },
+        mixpanel: { suffix: 'mixpanel', plugin: true },
+        piwik: { suffix: 'piwik', settings: config.settings, plugin: true },
+        segmentio: { suffix: 'segment.io', plugin: true },
+        splunk: { suffix: 'splunk', plugin: false },
+        woopra: { suffix: 'woopra', plugin: false }
     };
 
     var configuredProvider = availableProviders[config.provider];
 
     if (!configuredProvider) {
-        throw new Error ('Analytic provider \'' + config.provider + '\' not found. Check the available list of providers ' +
-                         'and set it using the \'provider\' property in the analytic module configuration.');
+        throw new Error('Analytic provider \'' + config.provider + '\' not found. Check the available list of providers ' +
+            'and set it using the \'provider\' property in the analytic module configuration.');
     } else {
-        require(['{angulartics}/angulartics-' + config.provider]);
+        if (configuredProvider.plugin) {
+            require(['{angulartics-' + configuredProvider.plugin + '}/src/angulartics-' + config.provider]);
+        } else {
+            require(['{angulartics}/angulartics-' + config.provider]);
+        }
 
         if (configuredProvider.settings) {
 
@@ -47,7 +51,7 @@ define([
 
                 var $injector = angular.injector(provider.angularModules, true);
 
-                $injector.invoke([provider.service, function (providerService) {
+                $injector.invoke([provider.service, function(providerService) {
                     if (providerService.configure) {
                         providerService.configure(configuredProvider.settings);
                     } else {
@@ -60,15 +64,13 @@ define([
         var W20ExtraAnalytics = angular.module('W20ExtraAnalytics', ['angulartics', 'angulartics.'.concat(configuredProvider.suffix)]);
         console.info('Analytic provider: ' + config.provider);
 
-        W20ExtraAnalytics.config(['$analyticsProvider', function ($analyticsProvider) {
+        W20ExtraAnalytics.config(['$analyticsProvider', function($analyticsProvider) {
             /* Enable/disable track all views */
             $analyticsProvider.virtualPageviews(config.virtualPageViews || true);
         }]);
 
         return {
-            angularModules: [ 'W20ExtraAnalytics' ]
+            angularModules: ['W20ExtraAnalytics']
         };
     }
 });
-
-

--- a/modules/providers/piwik-config.js
+++ b/modules/providers/piwik-config.js
@@ -18,7 +18,7 @@ define([
 
     var W20ExtraPiwik = angular.module('W20ExtraPiwik', ['ng']);
 
-    W20ExtraPiwik.factory('PiwikService', ['$window', function ($window) {
+    W20ExtraPiwik.factory('PiwikService', ['$window', '$http', function ($window, $http) {
 
         function addFileExtension(path) {
             var split = path.split('.');
@@ -37,16 +37,22 @@ define([
                     trackerUrl = settings.trackerUrl || [],
                     siteId = settings.siteId || [];
 
-                require([addFileExtension(jsUrl)], function() {
-                    if ($window._paq) {
-                        $window._paq.push(['trackPageView']);
-                        $window._paq.push(['enableLinkTracking']);
-                        $window._paq.push(['setTrackerUrl', trackerUrl]);
-                        $window._paq.push(['setSiteId', siteId]);
-                    } else {
-                        throw new Error('Unable to configure Piwik: _paq is not defined. Check the jsUrl parameter.');
-                    }
-                });
+               $http.get(jsUrl).then(function successCallback(response) {
+                    // this callback will be called asynchronously
+                    // when the response is available
+                    require([addFileExtension(jsUrl)], function () {
+                        if ($window._paq) {
+                            $window._paq.push(['trackPageView']);
+                            $window._paq.push(['enableLinkTracking']);
+                            $window._paq.push(['setTrackerUrl', trackerUrl]);
+                            $window._paq.push(['setSiteId', siteId]);
+                        } else {
+                            throw new Error('Unable to configure Piwik: _paq is not defined. Check the jsUrl parameter.');
+                        }
+                    });
+                }, function errorCallback(response) {
+                    console.warn('Analytic Piwik config : '.concat('settings parameter jsUrl [', jsUrl, '] couldn\'t be reached'));
+                });
             },
             getAPI: function() {
                 return $window.Piwik;

--- a/w20-extra.w20.json
+++ b/w20-extra.w20.json
@@ -1,11 +1,11 @@
 {
-    "id":"w20-extra",
-    "name":"W20 extra component",
-    "description":"W20 miscellaneous component",
+    "id": "w20-extra",
+    "name": "W20 extra component",
+    "description": "W20 miscellaneous component",
 
-    "modules" : {
-        "analytics" : {
-            "path" : "{w20-extra}/modules/analytics",
+    "modules": {
+        "analytics": {
+            "path": "{w20-extra}/modules/analytics",
             "configSchema": {
                 "title": "Analytics module configuration",
                 "type": "object",
@@ -27,8 +27,8 @@
                 }
             }
         },
-        "text" : {
-            "path" : "{w20-core}/modules/text",
+        "text": {
+            "path": "{w20-core}/modules/text",
             "configSchema": {
                 "title": "Text module configuration",
                 "type": "object",
@@ -40,11 +40,13 @@
     "requireConfig": {
         "paths": {
             "{angulartics}": "${components-path:bower_components}/angulartics/src",
+            "{angulartics-piwik}": "${components-path:bower_components}/angulartics-piwik/src",
             "showdown": "${components-path:bower_components}/showdown/dist/showdown"
         },
 
         "shim": {
-            "{angulartics}/angulartics": [ "{angular}/angular" ]
+            "{angulartics}/angulartics": ["{angular}/angular"],
+            "{angulartics-piwik}/src/angulartics-piwik": ["{angulartics}/angulartics"]
         }
     }
 }

--- a/w20-extra.w20.json
+++ b/w20-extra.w20.json
@@ -41,12 +41,38 @@
         "paths": {
             "{angulartics}": "${components-path:bower_components}/angulartics/src",
             "{angulartics-piwik}": "${components-path:bower_components}/angulartics-piwik/src",
+            "{angulartics-adobe-analytics}": "${components-path:bower_components}/angulartics-adobe-analytics/lib",
+            "{angulartics-chartbeat}": "${components-path:bower_components}/angulartics-chartbeat/lib",
+            "{angulartics-clicky}": "${components-path:bower_components}/angulartics-clicky/lib",
+            "{angulartics-facebook-pixel}": "${components-path:bower_components}/angulartics-facebook-pixel/lib",
+            "{angulartics-flurry}": "${components-path:bower_components}/angulartics-flurry/lib",
+            "{angulartics-google-analytics}": "${components-path:bower_components}/angulartics-google-analytics/lib",
+            "{angulartics-hubspot}": "${components-path:bower_components}/angulartics-hubspot/lib",
+            "{angulartics-coremetrics}": "${components-path:bower_components}/angulartics-coremetrics/lib",
+            "{angulartics-kissmetrics}": "${components-path:bower_components}/angulartics-kissmetrics/lib",
+            "{angulartics-localytics}": "${components-path:bower_components}/angulartics-localytics/lib",
+            "{angulartics-mixpanel}": "${components-path:bower_components}/angulartics-mixpanel/lib",
+            "{angulartics-scout}": "${components-path:bower_components}/angulartics-scout/lib",
+            "{angulartics-segment}": "${components-path:bower_components}/angulartics-segment/lib",
             "showdown": "${components-path:bower_components}/showdown/dist/showdown"
         },
 
         "shim": {
             "{angulartics}/angulartics": ["{angular}/angular"],
-            "{angulartics-piwik}/src/angulartics-piwik": ["{angulartics}/angulartics"]
+            "{angulartics-piwik}/angulartics-piwik": ["{angulartics}/angulartics"],
+            "{angulartics-adobe-analytics}/angulartics-piwik": ["{angulartics}/adobe-analytics"],
+            "{angulartics-chartbeat}/angulartics-piwik": ["{angulartics}/angulartics-chartbeat"],
+            "{angulartics-clicky}/angulartics-piwik": ["{angulartics}/angulartics-clicky"],
+            "{angulartics-facebook-pixel}/angulartics-piwik": ["{angulartics}/angulartics-facebook-pixel"],
+            "{angulartics-flurry}/angulartics-piwik": ["{angulartics}/angulartics-flurry"],
+            "{angulartics-google-analytics}/angulartics-piwik": ["{angulartics}/angulartics-ga"],
+            "{angulartics-hubspot}/angulartics-piwik": ["{angulartics}/angulartics-hubspot"],
+            "{angulartics-coremetrics}/angulartics-piwik": ["{angulartics}/angulartics-coremetrics"],
+            "{angulartics-kissmetrics}/angulartics-piwik": ["{angulartics}/angulartics-kissmetrics"],
+            "{angulartics-localytics}/angulartics-piwik": ["{angulartics}/angulartics-localytics"],
+            "{angulartics-mixpanel}/angulartics-piwik": ["{angulartics}/angulartics-mixpanel"],
+            "{angulartics-scout}/angulartics-piwik": ["{angulartics}/angulartics-scout"],
+            "{angulartics-segment}/angulartics-piwik": ["{angulartics}/angulartics-segment"]
         }
     }
 }


### PR DESCRIPTION
Angulartics does not provide by default the piwik module (see
https://github.com/angulartics/angulartics). angulartics-piwik plugin
bower component added.
Same requirements for other plugins defined in w20 add-on, if this pull request is valide, I can update the issue with all the plugins currently supported by w20-extras / analytics